### PR TITLE
Refactor sorting logic across multiple DAOs to default to descending …

### DIFF
--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/AppointmentDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/AppointmentDao.cs
@@ -192,6 +192,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         break;
                 }
             }
+            else
+            {
+                query = query.OrderByDescending(a => a.AppointmentId);
+            }
 
             var total = await query.CountAsync();
             var appointments = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/AppointmentSlotDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/AppointmentSlotDao.cs
@@ -124,6 +124,11 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                     _ => isAscending ? query.OrderBy(s => s.SlotId) : query.OrderByDescending(s => s.SlotId),
                 };
             }
+            else
+            {
+                // Default: Sort by StartTime ascending for easier slot selection
+                query = query.OrderBy(s => s.StartTime);
+            }
 
             var total = await query.CountAsync();
             var slots = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ConversationDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ConversationDao.cs
@@ -63,6 +63,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         break;
                 }
             }
+            else
+            {
+                query = query.OrderByDescending(c => c.ConversationId);
+            }
 
             var total = await query.CountAsync();
             var conversations = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/EmployeeDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/EmployeeDao.cs
@@ -79,6 +79,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                     _ => isAscending ? query.OrderBy(e => e.EmployeeId) : query.OrderByDescending(e => e.EmployeeId),
                 };
             }
+            else
+            {
+                query = query.OrderByDescending(e => e.EmployeeId);
+            }
 
             var total = await query.CountAsync();
             var employees = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/MaintenanceHistoryDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/MaintenanceHistoryDao.cs
@@ -77,6 +77,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         break;
                 }
             }
+            else
+            {
+                query = query.OrderByDescending(h => h.HistoryId);
+            }
 
             var total = await query.CountAsync();
             var histories = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartDao.cs
@@ -72,7 +72,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
             }
             else
             {
-                query = query.OrderBy(p => p.PartId);
+                query = query.OrderByDescending(p => p.PartId);
             }
 
             var total = await query.CountAsync();

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceCenterDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceCenterDao.cs
@@ -87,7 +87,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
             }
             else
             {
-                query = query.OrderBy(c => c.CenterId);
+                query = query.OrderByDescending(c => c.CenterId);
             }
 
             var total = await query.CountAsync();
@@ -183,6 +183,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         query = isAscending ? query.OrderBy(c => c.CenterId) : query.OrderByDescending(c => c.CenterId);
                         break;
                 }
+            }
+            else
+            {
+                query = query.OrderByDescending(c => c.CenterId);
             }
 
             var total = await query.CountAsync();

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceDao.cs
@@ -159,7 +159,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
         private static IQueryable<Service> ApplySorting(IQueryable<Service> query, string? sortBy, string sortOrder)
         {
             if (string.IsNullOrEmpty(sortBy))
-                return query.OrderBy(s => s.ServiceId);
+                return query.OrderByDescending(s => s.ServiceId);
 
             bool isAscending = sortOrder.Equals("asc", StringComparison.OrdinalIgnoreCase);
 

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/UserDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/UserDao.cs
@@ -232,7 +232,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
         private static IQueryable<User> ApplySorting(IQueryable<User> query, string? sortBy, string sortOrder)
         {
             if (sortBy == null || string.IsNullOrWhiteSpace(sortBy))
-                return query.OrderBy(u => u.UserId);
+                return query.OrderByDescending(u => u.UserId);
 
             bool isAscending = sortOrder.Equals("asc", StringComparison.OrdinalIgnoreCase);
 

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/VehicleDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/VehicleDao.cs
@@ -126,6 +126,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         break;
                 }
             }
+            else
+            {
+                query = query.OrderByDescending(v => v.VehicleId);
+            }
 
             var total = await query.CountAsync();
             var vehicles = await query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/WorkOrderDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/WorkOrderDao.cs
@@ -150,9 +150,13 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                         query = queryParams.SortOrder == "desc" ? query.OrderByDescending(wo => wo.CheckInAt) : query.OrderBy(wo => wo.CheckInAt);
                         break;
                     default:
-                        query = query.OrderBy(wo => wo.WorkOrderId);
+                        query = queryParams.SortOrder == "desc" ? query.OrderByDescending(wo => wo.WorkOrderId) : query.OrderBy(wo => wo.WorkOrderId);
                         break;
                 }
+            }
+            else
+            {
+                query = query.OrderByDescending(wo => wo.WorkOrderId);
             }
 
             query = query

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Params/QueryParams.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Params/QueryParams.cs
@@ -4,7 +4,7 @@
     {
         private int _page = 1;
         private int _pageSize = 10;
-        private string _sortOrder = "asc";
+        private string _sortOrder = "desc";
 
         //public virtual string? Type { get; set; }
 


### PR DESCRIPTION
…order

- Updated AppointmentDao, AppointmentSlotDao, ConversationDao, EmployeeDao, MaintenanceHistoryDao, PartDao, ServiceCenterDao, ServiceDao, UserDao, VehicleDao, WorkOrderDao to apply descending order sorting by default when no specific sort criteria is provided.
- Adjusted QueryParams to set default sort order to descending for consistency across the application.

These changes enhance the data retrieval process by ensuring a consistent sorting order.