### PR TITLE
Enhance service center deletion process and part management

### DIFF
--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Controllers/ServiceCenterController.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Controllers/ServiceCenterController.cs
@@ -127,16 +127,28 @@ namespace EVServiceCenterMaintenanceAPI.Controllers
 
         [HttpDelete("{id}")]
         [Authorize(Roles = "Admin")]
-        public async Task<IActionResult> DeleteServiceCenter(int id)
+        public async Task<IActionResult> DeleteServiceCenter(int id, [FromQuery] int targetCenterId)
         {
             try
             {
-                await _serviceCenterDao.DeleteServiceCenterAsync(id);
-                return Ok(new ApiResponse<object>(200, "Success", "Service center deleted successfully."));
+                var (transferred, merged) = await _serviceCenterDao.DeleteServiceCenterAsync(id, targetCenterId);
+
+                var message = $"Service center deleted successfully. Parts transferred: {transferred} part(s) created, {merged} part(s) merged into existing inventory.";
+
+                return Ok(new ApiResponse<object>(
+                    200,
+                    "Success",
+                    message,
+                    data: new { transferred, merged }
+                ));
             }
             catch (KeyNotFoundException ex)
             {
                 return NotFound(new ApiResponse<object>(404, "NotFound", ex.Message));
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new ApiResponse<object>(400, "BadRequest", ex.Message));
             }
             catch (Exception ex)
             {

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartDao.cs
@@ -1,4 +1,5 @@
 ﻿using EVServiceCenterMaintenanceAPI.DTO;
+using EVServiceCenterMaintenanceAPI.Enums;
 using EVServiceCenterMaintenanceAPI.Models;
 using EVServiceCenterMaintenanceAPI.Params;
 using Microsoft.EntityFrameworkCore;
@@ -46,7 +47,10 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new ArgumentException(ErrorMessage);
             }
 
-            var query = _context.Parts.AsQueryable();
+            var query = queryParams.StatusPart.HasValue
+                ? _context.Parts.IgnoreQueryFilters().AsQueryable()
+                : _context.Parts.AsQueryable();
+
             if (!string.IsNullOrEmpty(queryParams.Search))
                 query = query.Where(p => p.PartName.Contains(queryParams.Search));
             if (queryParams.CenterId.HasValue)
@@ -148,9 +152,85 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new KeyNotFoundException($"Part with ID {partId} not found.");
 
             // Soft delete: Set Status = Inactive
-            part.Status = "Inactive";
+            part.Status = PartStatus.Inactive.ToString();
             part.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
+        }
+
+        public async Task<(int Transferred, int Merged)> TransferPartsToAnotherCenterAsync(int sourceCenterId, int targetCenterId)
+        {
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                // Lấy TẤT CẢ parts của center nguồn
+                var sourceParts = await _context.Parts
+                    .Where(p => p.CenterId == sourceCenterId)
+                    .ToListAsync();
+
+                if (sourceParts.Count == 0)
+                {
+                    await transaction.CommitAsync();
+                    return (0, 0); // Không có parts cần transfer
+                }
+
+                // Lấy TẤT CẢ parts của center đích
+                var targetParts = await _context.Parts
+                    .Where(p => p.CenterId == targetCenterId)
+                    .ToListAsync();
+
+                int transferredCount = 0;
+                int mergedCount = 0;
+
+                foreach (var sourcePart in sourceParts)
+                {
+                    // Tìm part tương tự ở center đích
+                    var matchingTargetPart = targetParts.FirstOrDefault(tp =>
+                        tp.PartName.Equals(sourcePart.PartName, StringComparison.OrdinalIgnoreCase) &&
+                        tp.Price == sourcePart.Price);
+
+                    if (matchingTargetPart != null)
+                    {
+                        // MERGE: Cộng dồn số lượng vào part đích
+                        matchingTargetPart.QuantityInStock = (matchingTargetPart.QuantityInStock ?? 0) + (sourcePart.QuantityInStock ?? 0);
+                        matchingTargetPart.UpdatedAt = DateTime.UtcNow;
+                        mergedCount++;
+                    }
+                    else
+                    {
+                        // TRANSFER: Tạo Part MỚI ở center đích
+                        var newPart = new Part
+                        {
+                            PartName = sourcePart.PartName,
+                            Description = sourcePart.Description,
+                            CostPrice = sourcePart.CostPrice,
+                            Price = sourcePart.Price,
+                            QuantityInStock = sourcePart.QuantityInStock,
+                            MinStock = sourcePart.MinStock,
+                            CenterId = targetCenterId,
+                            Status = PartStatus.Active.ToString(),
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
+                        };
+                        _context.Parts.Add(newPart);
+                        transferredCount++;
+                    }
+
+                    // Soft delete part nguồn và RESET quantity = 0
+                    sourcePart.Status = PartStatus.Inactive.ToString();
+                    sourcePart.QuantityInStock = 0;
+                    sourcePart.UpdatedAt = DateTime.UtcNow;
+                }
+
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+
+                return (transferredCount, mergedCount);
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync();
+                throw new Exception($"Failed to transfer parts from center {sourceCenterId} to center {targetCenterId}.", ex);
+            }
         }
     }
 }

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartUsageDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/PartUsageDao.cs
@@ -1,3 +1,4 @@
+using EVServiceCenterMaintenanceAPI.Enums;
 using EVServiceCenterMaintenanceAPI.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -33,7 +34,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
             }
 
             // Check if part is active
-            if (part.Status != "Active")
+            if (part.Status != PartStatus.Active.ToString())
             {
                 throw new InvalidOperationException($"Part '{part.PartName}' is not active. Cannot use inactive parts.");
             }
@@ -286,7 +287,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 return (false, $"Part with ID {partId} not found.", null);
             }
 
-            if (part.Status != "Active")
+            if (part.Status != PartStatus.Active.ToString())
             {
                 return (false, $"Part '{part.PartName}' is not active.", part);
             }

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceCenterDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceCenterDao.cs
@@ -8,10 +8,12 @@ namespace EVServiceCenterMaintenanceAPI.DAO
     public class ServiceCenterDao
     {
         private readonly EvserviceCenterDbContext _context;
+        private readonly PartDao _partDao;
 
-        public ServiceCenterDao(EvserviceCenterDbContext context)
+        public ServiceCenterDao(EvserviceCenterDbContext context, PartDao partDao)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
+            _partDao = partDao ?? throw new ArgumentNullException(nameof(partDao));
         }
 
         public Task<bool> IsExistServiceCenterAsync(int serviceCenterId)
@@ -54,21 +56,14 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new ArgumentException(ErrorMessage);
             }
 
-            var query = _context.ServiceCenters.AsQueryable();
+            var query = queryParams.StatusServiceCenter.HasValue
+                ? _context.ServiceCenters.IgnoreQueryFilters().AsQueryable()
+                : _context.ServiceCenters.AsQueryable();
 
             if (!string.IsNullOrEmpty(queryParams.Search))
                 query = query.Where(c => c.CenterName.Contains(queryParams.Search) || c.Address.Contains(queryParams.Search));
-
-            // Filter by Status: Nếu có chọn Status thì dùng Status đó, nếu không thì ẩn Deleted
             if (queryParams.StatusServiceCenter.HasValue)
-            {
                 query = query.Where(c => c.Status == queryParams.StatusServiceCenter.ToString());
-            }
-            else
-            {
-                // Mặc định: không show Deleted
-                query = query.Where(c => c.Status != "Deleted");
-            }
             if (queryParams.FromDate.HasValue)
                 query = query.Where(c => c.CreatedAt >= queryParams.FromDate.Value);
             if (queryParams.ToDate.HasValue)
@@ -99,16 +94,46 @@ namespace EVServiceCenterMaintenanceAPI.DAO
             return (centers, total);
         }
 
-        public async Task DeleteServiceCenterAsync(int centerId)
+        public async Task<(int Transferred, int Merged)> DeleteServiceCenterAsync(int centerId, int targetCenterId)
         {
-            var center = await _context.ServiceCenters.FindAsync(centerId);
-            if (center == null)
-                throw new KeyNotFoundException($"Service center with ID {centerId} not found.");
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                // Validate center nguồn tồn tại
+                var center = await _context.ServiceCenters.FindAsync(centerId);
+                if (center == null)
+                    throw new KeyNotFoundException($"Service center with ID {centerId} not found.");
 
-            // Soft delete: Set Status = Deleted
-            center.Status = "Deleted";
-            center.UpdatedAt = DateTime.UtcNow;
-            await _context.SaveChangesAsync();
+                // Validate center đích tồn tại
+                var targetCenter = await _context.ServiceCenters.FindAsync(targetCenterId);
+                if (targetCenter == null)
+                    throw new KeyNotFoundException($"Target service center with ID {targetCenterId} not found.");
+
+                // Validate center đích không phải là center nguồn
+                if (centerId == targetCenterId)
+                    throw new ArgumentException("Target center must be different from the center being deleted.");
+
+                // Validate center đích không bị Deleted
+                if (targetCenter.Status == ServiceCenterStatus.Deleted.ToString())
+                    throw new ArgumentException($"Cannot transfer parts to a deleted service center (ID: {targetCenterId}).");
+
+                // Transfer tất cả parts sang center đích
+                var (transferred, merged) = await _partDao.TransferPartsToAnotherCenterAsync(centerId, targetCenterId);
+
+                // Soft delete center nguồn
+                center.Status = ServiceCenterStatus.Deleted.ToString();
+                center.UpdatedAt = DateTime.UtcNow;
+                await _context.SaveChangesAsync();
+
+                await transaction.CommitAsync();
+
+                return (transferred, merged);
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
         }
 
         public async Task<ServiceCenter> UpdateServiceCenterAsync(ServiceCenter center)

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/ServiceDao.cs
@@ -151,7 +151,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new KeyNotFoundException($"Service with ID {serviceId} not found.");
 
             // Soft delete: Set Status = Inactive
-            service.Status = "Inactive";
+            service.Status = ServiceStatus.Inactive.ToString();
             service.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
         }

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/UserDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/UserDao.cs
@@ -119,7 +119,9 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new ArgumentException(ErrorMessage);
             }
 
-            var query = _context.Users.AsQueryable();
+            var query = queryParams.StatusUser.HasValue
+                ? _context.Users.IgnoreQueryFilters().AsQueryable()
+                : _context.Users.AsQueryable();
 
             if (centerUserIds != null)
             {
@@ -130,17 +132,8 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 query = query.Where(u => u.Username.Contains(queryParams.Search) || u.FullName.Contains(queryParams.Search) || u.Email.Contains(queryParams.Search));
             if (queryParams.Role.HasValue)
                 query = query.Where(u => u.Role == queryParams.Role.ToString());
-
-            // Filter by Status: Nếu có chọn Status thì dùng Status đó, nếu không thì ẩn Deleted
             if (queryParams.StatusUser.HasValue)
-            {
                 query = query.Where(u => u.Status == queryParams.StatusUser.ToString());
-            }
-            else
-            {
-                // Mặc định: không show Deleted
-                query = query.Where(u => u.Status != "Deleted");
-            }
             if (queryParams.FromDate.HasValue)
                 query = query.Where(u => u.CreatedAt >= queryParams.FromDate.Value);
             if (queryParams.ToDate.HasValue)
@@ -176,7 +169,7 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 throw new KeyNotFoundException($"User with ID {userId} not found.");
 
             // Soft delete: Set Status = Deleted
-            user.Status = "Deleted";
+            user.Status = UserStatus.Deleted.ToString();
             user.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
         }

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Models/EvserviceCenterDbContext.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Models/EvserviceCenterDbContext.cs
@@ -600,6 +600,10 @@ public partial class EvserviceCenterDbContext : DbContext
                 .HasConstraintName("FK_WorkOrder_Vehicles");
         });
 
+        modelBuilder.Entity<User>().HasQueryFilter(u => u.Status != Enums.UserStatus.Deleted.ToString());
+        modelBuilder.Entity<ServiceCenter>().HasQueryFilter(sc => sc.Status != Enums.ServiceCenterStatus.Deleted.ToString());
+        modelBuilder.Entity<Part>().HasQueryFilter(p => p.Status != Enums.PartStatus.Inactive.ToString());
+
         OnModelCreatingPartial(modelBuilder);
     }
 


### PR DESCRIPTION
- Updated DeleteServiceCenter method to transfer parts to a target center before deletion, returning counts of transferred and merged parts.
- Introduced TransferPartsToAnotherCenterAsync method in PartDao to handle part transfers and merging logic.
- Refactored status handling for parts and service centers to use enums for better maintainability.
- Added query filters to exclude inactive and deleted entities from queries across multiple DAOs.