### PR TITLE
Enhance Vehicle Retrieval by Adding Availability Filter

### DIFF
--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Controllers/VehicleController.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/Controllers/VehicleController.cs
@@ -168,7 +168,7 @@ namespace EVServiceCenterMaintenanceAPI.Controllers
 
         [HttpGet("customer/{customerId}")]
         [Authorize(Roles = "Customer,Staff,Admin")]
-        public async Task<IActionResult> GetVehiclesByCustomer(int customerId)
+        public async Task<IActionResult> GetVehiclesByCustomer(int customerId, [FromQuery] bool availableOnly = false)
         {
             try
             {
@@ -184,7 +184,7 @@ namespace EVServiceCenterMaintenanceAPI.Controllers
                 }
                 // Staff and Admin can view vehicles for any customer
 
-                var vehicles = await _vehicleDao.GetVehiclesByCustomerIdAsync(customerId);
+                var vehicles = await _vehicleDao.GetVehiclesByCustomerIdAsync(customerId, availableOnly);
                 var dtos = vehicles.Select(v => new VehicleResponeDto
                 {
                     VehicleId = v.VehicleId,

--- a/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/VehicleDao.cs
+++ b/EVServiceCenterMaintenanceAPI/EVServiceCenterMaintenanceAPI/DAO/VehicleDao.cs
@@ -70,22 +70,28 @@ namespace EVServiceCenterMaintenanceAPI.DAO
                 .FirstOrDefaultAsync(v => v.VehicleId == vehicleId);
         }
 
-        public async Task<List<Vehicle>> GetVehiclesByCustomerIdAsync(int customerId)
+        public async Task<List<Vehicle>> GetVehiclesByCustomerIdAsync(int customerId, bool availableOnly = false)
         {
-            // Customer chỉ xem vehicles Active của mình
-            return await _context.Vehicles
+            var query = _context.Vehicles
                 .Where(v => v.CustomerId == customerId &&
-                            v.Status == VehicleStatus.Active.ToString() &&
-                            !v.Appointments.Any(a =>
-                                a.Status == AppointmentStatus.Pending.ToString() ||
-                                a.Status == AppointmentStatus.Confirmed.ToString() ||
-                                a.Status == AppointmentStatus.InProgress.ToString()) &&
-                            !v.WorkOrders.Any(w =>
-                                w.Status == WorkOrderStatus.Pending.ToString() ||
-                                w.Status == WorkOrderStatus.InProgress.ToString()))
+                            v.Status == VehicleStatus.Active.ToString())
                 .Include(v => v.Customer)
                 .Include(v => v.MaintenanceHistories)
-                .ToListAsync();
+                .AsQueryable();
+
+            if (availableOnly)
+            {
+                query = query.Where(v =>
+                    !v.Appointments.Any(a =>
+                        a.Status == AppointmentStatus.Pending.ToString() ||
+                        a.Status == AppointmentStatus.Confirmed.ToString() ||
+                        a.Status == AppointmentStatus.InProgress.ToString()) &&
+                    !v.WorkOrders.Any(w =>
+                        w.Status == WorkOrderStatus.Pending.ToString() ||
+                        w.Status == WorkOrderStatus.InProgress.ToString()));
+            }
+
+            return await query.ToListAsync();
         }
 
         public async Task<(List<Vehicle> Vehicles, int Total)> GetAllVehiclesAsync(VehicleQueryParams queryParams)


### PR DESCRIPTION
- Updated VehicleController to include an optional query parameter `availableOnly` for filtering vehicles based on availability.
- Modified VehicleDao to support the new parameter, allowing customers to retrieve only active vehicles without pending appointments or work orders.
- Improved query efficiency by utilizing IQueryable for dynamic filtering based on the availability status.